### PR TITLE
use supplied logger only for error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Install via `go get github.com/xing/logjam-agent-go`.
 logjam.SetupAgent(&logjam.Options{
 	AppName: "MyApp",
 	EnvName: "production",
-	Logger:	 log.New(os.Stderr, "API", log.LstdFlags),
 )
 ```
 

--- a/gorilla/gorilla_test.go
+++ b/gorilla/gorilla_test.go
@@ -2,10 +2,10 @@ package gorilla
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/golang/snappy"
@@ -41,14 +41,11 @@ func TestGorillaNameExtraction(t *testing.T) {
 	router.Path("/allmethods").HandlerFunc(somebody)
 	router.Path("/simple").Methods("GET").HandlerFunc(somebody)
 
-	fs, _ := os.Open(os.DevNull)
-	logger := log.New(fs, "API", log.LstdFlags|log.Lshortfile)
-
 	agentOptions := logjam.Options{
 		Endpoints: "127.0.0.1,localhost",
 		AppName:   "appName",
 		EnvName:   "envName",
-		Logger:    logger,
+		Logger:    log.New(ioutil.Discard, "", 0),
 	}
 	logjam.SetupAgent(&agentOptions)
 	defer logjam.ShutdownAgent()

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -2,6 +2,7 @@ package logjam
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -72,14 +73,11 @@ func TestMiddleware(t *testing.T) {
 		})
 	})
 
-	fs, _ := os.Open(os.DevNull)
-	logger := log.New(fs, "API", log.LstdFlags|log.Lshortfile)
-
 	agentOptions := Options{
 		Endpoints:    "127.0.0.1,localhost",
 		AppName:      "appName",
 		EnvName:      "envName",
-		Logger:       logger,
+		Logger:       log.New(ioutil.Discard, "", 0),
 		ObfuscateIPs: true,
 	}
 	SetupAgent(&agentOptions)

--- a/request.go
+++ b/request.go
@@ -91,7 +91,6 @@ func (r *Request) Log(severity LogLevel, line string) {
 	if r.severity < severity {
 		r.severity = severity
 	}
-	logger.Println(line)
 
 	if r.logLinesBytesCount > agent.MaxBytesAllLines {
 		return
@@ -151,7 +150,7 @@ func (r *Request) Finish(code int) {
 
 	buf, err := json.Marshal(&payload)
 	if err != nil {
-		logger.Println(err)
+		agent.Logger.Println(err)
 		return
 	}
 	data := snappy.Encode(nil, buf)

--- a/request_test.go
+++ b/request_test.go
@@ -1,9 +1,9 @@
 package logjam
 
 import (
+	"io/ioutil"
 	"log"
 	"math"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -62,8 +62,7 @@ func TestSettingFields(t *testing.T) {
 }
 
 func TestLog(t *testing.T) {
-	fs, _ := os.Open(os.DevNull)
-	SetupAgent(&Options{Logger: log.New(fs, "API", log.LstdFlags|log.Lshortfile)})
+	SetupAgent(&Options{Logger: log.New(ioutil.Discard, "", 0)})
 
 	now := time.Date(1970, 1, 1, 1, 0, 0, 0, time.Now().Location())
 	maxLineLength := agent.MaxLineLength


### PR DESCRIPTION
Request.Log() no longer passes the log line back to the supplied logger. If you want to log to both logjam and a custom logger it's your responsibility not logjams.