### PR TITLE
change Log() signature to require context as first parameter

### DIFF
--- a/gorilla/gorilla.go
+++ b/gorilla/gorilla.go
@@ -19,7 +19,7 @@ type handler struct {
 }
 
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	request := logjam.GetRequest(r)
+	request := logjam.GetRequest(r.Context())
 	if request != nil {
 		request.ChangeAction(w, h.actionName(r.Method))
 	}

--- a/middleware.go
+++ b/middleware.go
@@ -1,6 +1,7 @@
 package logjam
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -162,8 +163,8 @@ func ipv4for(host string) (net.IP, error) {
 
 // SetCallHeaders makes sure all X-Logjam-* Headers are copied into the outgoing
 // request. Call this before you call other APIs.
-func SetCallHeaders(hc HasContext, outgoing *http.Request) {
-	incoming := GetRequest(hc)
+func SetCallHeaders(ctx context.Context, outgoing *http.Request) {
+	incoming := GetRequest(ctx)
 	if incoming == nil {
 		return
 	}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -55,13 +55,13 @@ func TestMiddleware(t *testing.T) {
 	router := mux.NewRouter()
 
 	router.Path("/rest/app/vendor/v1/users/123").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		Log(req, 500, "First Line")
-		Log(req, FATAL, "Second Line")
-		Log(req, ERROR, "Third Line")
-		Log(req, WARN, "Fourth Line")
-		Log(req, INFO, "Sixth Line")
+		Log(req.Context(), 500, "First Line")
+		Log(req.Context(), FATAL, "Second Line")
+		Log(req.Context(), ERROR, "Third Line")
+		Log(req.Context(), WARN, "Fourth Line")
+		Log(req.Context(), INFO, "Sixth Line")
 
-		r := GetRequest(req)
+		r := GetRequest(req.Context())
 		r.AddCount("rest_calls", 1)
 		r.AddDuration("rest_time", 5*time.Second)
 		r.SetField("sender_id", "foobar")
@@ -202,7 +202,7 @@ func TestSetCallHeaders(t *testing.T) {
 		logjamRequest := NewRequest("foobar")
 		wrapped := logjamRequest.AugmentRequest(incoming)
 		outgoing := httptest.NewRequest("GET", "/", nil)
-		SetCallHeaders(wrapped, outgoing)
+		SetCallHeaders(wrapped.Context(), outgoing)
 		So(outgoing.Header.Get("X-Logjam-Action"), ShouldEqual, "foobar")
 		So(outgoing.Header.Get("X-Logjam-Caller-Id"), ShouldEqual, logjamRequest.id)
 	})

--- a/request.go
+++ b/request.go
@@ -71,10 +71,10 @@ func (r *Request) ChangeAction(w http.ResponseWriter, action string) {
 	w.Header().Set("X-Logjam-Action", action)
 }
 
-// GetRequest retrieves a logjam request from an object with Context. Returns nil if no
+// GetRequest retrieves a logjam request from an Context. Returns nil if no
 // request is stored in the context.
-func GetRequest(hc HasContext) *Request {
-	v, ok := hc.Context().Value(requestKey).(*Request)
+func GetRequest(ctx context.Context) *Request {
+	v, ok := ctx.Value(requestKey).(*Request)
 	if ok {
 		return v
 	}

--- a/util.go
+++ b/util.go
@@ -5,11 +5,6 @@ import (
 	"fmt"
 )
 
-// HasContext is any object that reponds to the Context method.
-type HasContext interface {
-	Context() context.Context
-}
-
 // LogLevel (modeled afterRuby log levels).
 type LogLevel int
 
@@ -24,33 +19,33 @@ const (
 // Log takes a context to be able to collect all logs within the same request.
 // If you're using gin-gonic, please pass the (*gin.Context).Request.Context()
 // Maximum line length is 2048 characters.
-func Log(hc HasContext, severity LogLevel, format string, args ...interface{}) {
-	if request := GetRequest(hc); request != nil {
+func Log(ctx context.Context, severity LogLevel, format string, args ...interface{}) {
+	if request := GetRequest(ctx); request != nil {
 		request.Log(severity, fmt.Sprintf(format, args...))
 	}
 }
 
 // LogDebug calls Log with DEBUG severity.
-func LogDebug(hc HasContext, format string, args ...interface{}) {
-	Log(hc, DEBUG, format, args...)
+func LogDebug(ctx context.Context, format string, args ...interface{}) {
+	Log(ctx, DEBUG, format, args...)
 }
 
 // LogInfo calls Log with INFO severity.
-func LogInfo(hc HasContext, format string, args ...interface{}) {
-	Log(hc, INFO, format, args...)
+func LogInfo(ctx context.Context, format string, args ...interface{}) {
+	Log(ctx, INFO, format, args...)
 }
 
 // LogWarn calls Log with WARN severity.
-func LogWarn(hc HasContext, format string, args ...interface{}) {
-	Log(hc, WARN, format, args...)
+func LogWarn(ctx context.Context, format string, args ...interface{}) {
+	Log(ctx, WARN, format, args...)
 }
 
 // LogError calls Log with ERROR severity.
-func LogError(hc HasContext, format string, args ...interface{}) {
-	Log(hc, ERROR, format, args...)
+func LogError(ctx context.Context, format string, args ...interface{}) {
+	Log(ctx, ERROR, format, args...)
 }
 
 // LogFatal calls Log with FATAL severity.
-func LogFatal(hc HasContext, format string, args ...interface{}) {
-	Log(hc, FATAL, format, args...)
+func LogFatal(ctx context.Context, format string, args ...interface{}) {
+	Log(ctx, FATAL, format, args...)
 }


### PR DESCRIPTION
Now the signature matches the description. ;-)

I know this is a breaking change but it should be easy to update.