### PR TITLE
remove logger option from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Install via `go get github.com/xing/logjam-agent-go`.
 logjam.SetupAgent(&logjam.Options{
 	AppName: "MyApp",
 	EnvName: "production",
-	Logger:	 log.New(os.Stderr, "API", log.LstdFlags),
 })
 ```
 


### PR DESCRIPTION
Since it's now only used for logging logjam errors I wouldn't put it so prominently in the README. I was confused by it in the beginng and thought I had to provide one.