### PR TITLE
add heap metrics

### DIFF
--- a/request.go
+++ b/request.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"runtime"
 	"sync"
 	"time"
 
@@ -195,16 +196,21 @@ func (r *Request) durationCorrectionFactor(totalTime float64) float64 {
 }
 
 func (r *Request) logjamPayload(code int) map[string]interface{} {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
 	totalTime := r.totalTime()
 	msg := map[string]interface{}{
-		"action":     r.action,
-		"code":       code,
-		"process_id": os.Getpid(),
-		"request_id": r.uuid,
-		"severity":   r.severity,
-		"started_at": r.startTime.Format(timeFormat),
-		"started_ms": r.startTime.UnixNano() / 1000000,
-		"total_time": totalTime,
+		"action":             r.action,
+		"code":               code,
+		"process_id":         os.Getpid(),
+		"request_id":         r.uuid,
+		"severity":           r.severity,
+		"started_at":         r.startTime.Format(timeFormat),
+		"started_ms":         r.startTime.UnixNano() / 1000000,
+		"total_time":         totalTime,
+		"live_data_set_size": ms.HeapAlloc,
+		"heap_size":          ms.HeapSys / 1000000,
 	}
 	if len(r.logLines) > 0 {
 		msg["lines"] = r.logLines

--- a/request.go
+++ b/request.go
@@ -210,7 +210,7 @@ func (r *Request) logjamPayload(code int) map[string]interface{} {
 		"started_ms":         r.startTime.UnixNano() / 1000000,
 		"total_time":         totalTime,
 		"live_data_set_size": ms.HeapAlloc,
-		"heap_size":          ms.HeapSys / 1000000,
+		"heap_size":          ms.HeapSys,
 	}
 	if len(r.logLines) > 0 {
 		msg["lines"] = r.logLines


### PR DESCRIPTION
Let's talk about this when you have time and slack is back up. :-) I have it running in preview.

[MemStats](https://golang.org/pkg/runtime/#MemStats)

`HeapAlloc is bytes of allocated heap objects.`
`HeapSys is bytes of heap memory obtained from the OS.`

We could also look into [MemProfileRecord](https://golang.org/pkg/runtime/#MemProfileRecord) if we want to track allocations during a request.
